### PR TITLE
add pip to eliminate warning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python
   - numpy
+  - pip
   - pip:
     - nbgitpuller
     - sphinx-gallery


### PR DESCRIPTION
Currently, I am seeing conda(?) nagging about using pip to install pip-installable dependencies in `environment.yml` but not including `pip` in the main list of dependencies. When just simply listing `- pip:` with a dependence to be installed by `pip`, it nags and actually uses the word 'nagging' in the warning. Adding `pip` to the main list  seems to fix. (Although it does look a bit redundant.)